### PR TITLE
Explicitly use the metacraft-labs Vercel scope

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,11 +71,11 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v2
       - name: Pull Vercel configuration
-        run: yarn vercel pull --yes --token ${{ secrets.vercel_token }}
+        run: yarn vercel pull --scope metacraft-labs --yes --token ${{ secrets.vercel_token }}
       - name: Build Vercel bundle
         run: yarn vercel build --prod
       - name: Deploy to Vercel
-        run: yarn vercel deploy --prebuilt --prod --token ${{ secrets.vercel_token }} > _vercel-deployment-url
+        run: yarn vercel deploy --scope metacraft-labs --prebuilt --prod --token ${{ secrets.vercel_token }} > _vercel-deployment-url
       - name: Add deployment
         uses: actions/github-script@v6
         id: vercel-deployment

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ permissions:
   deployments: write
 
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -58,11 +58,11 @@ jobs:
       - name: Check formatting
         run: yarn format:check
       - name: Pull Vercel configuration
-        run: yarn vercel pull --yes --token ${{ secrets.vercel_token }}
+        run: yarn vercel pull --scope metacraft-labs --yes --token ${{ secrets.vercel_token }}
       - name: Build Vercel bundle
         run: yarn vercel build
       - name: Deploy to Vercel
-        run: yarn vercel deploy --prebuilt --token ${{ secrets.vercel_token }} > _vercel-deployment-url
+        run: yarn vercel deploy --scope metacraft-labs --prebuilt --token ${{ secrets.vercel_token }} > _vercel-deployment-url
       - name: Comment on PR with deployment URL
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -148,4 +148,3 @@ jobs:
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npx http-server storybook-static --port 6006 --silent" \
             "npx wait-on tcp:127.0.0.1:6006 && yarn test-storybook"
-


### PR DESCRIPTION
We are switching to a paid team account in order to be able to grant multiple developers the necessary access to our PR deployments.