### PR TITLE
Remove undefined in balance chart

### DIFF
--- a/src/pages/Dashboard/BalanceChartCard/LineChart.tsx
+++ b/src/pages/Dashboard/BalanceChartCard/LineChart.tsx
@@ -25,9 +25,9 @@ const LineChart = ({ years, userGains }: LineChartProps) => {
         data: userGains,
         borderColor: '#1992D7',
         backgroundColor: '#f6fbfd',
-        fill: true,
         tension: 0.4,
         pointRadius: 0,
+        label: 'Balance',
       },
     ],
   }


### PR DESCRIPTION
Closes #141

I replaced "undefined" with "Balance" label, because I couldn't remove entirely this blue section. 
[Link](https://react-chartjs-2.js.org/examples/line-chart) to exact chart component from react-chartjs-2 library
![image](https://github.com/nimbus-gui/nimbus-gui/assets/101931596/41c81892-6c52-4024-b5f6-cb69e221fcaa)
